### PR TITLE
Remove rarely used CLI option counterparts of some config options

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -81,8 +81,6 @@ These are top-level fields whose values control various settings of the viewer.
 
    If less than ``2``, directory sources are checked within the main process.
 
-   .. note:: Overridden by :option:`--checkers`.
-
 .. confval:: getters
    :synopsis: Number of threads for downloading images from URL sources.
    :type: integer

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -95,8 +95,6 @@ These are top-level fields whose values control various settings of the viewer.
 
    If ``0`` (zero), grid cells are rendered by a thread of the main process.
 
-   .. note:: Overridden by :option:`--grid-renderers`.
-
 .. confval:: log file
    :synopsis: The file to which logs are written.
    :type: string

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -87,8 +87,6 @@ These are top-level fields whose values control various settings of the viewer.
    :valid: *x* > ``0``
    :default: ``4``
 
-   .. note:: Overridden by :option:`--getters`.
-
 .. confval:: grid renderers
    :synopsis: Number of subprocesses for rendering grid cells.
    :type: integer

--- a/src/termvisage/cli.py
+++ b/src/termvisage/cli.py
@@ -818,7 +818,7 @@ def main() -> None:
             args=(url_queue, url_images, ImageClass),
             name=f"Getter-{n}",
         )
-        for n in range(1, args.getters + 1)
+        for n in range(1, config_options.getters + 1)
     ]
     getters_started = False
 
@@ -884,7 +884,7 @@ def main() -> None:
 
     # Signal end of sources
     if getters_started:
-        for _ in range(args.getters):
+        for _ in range(config_options.getters):
             url_queue.put(None)
     if opener_started:
         file_queue.put(None)

--- a/src/termvisage/parsers.py
+++ b/src/termvisage/parsers.py
@@ -602,15 +602,6 @@ perf_options.add_argument(
     help="Apply :option:`--max-pixels` in CLI mode",
 )
 perf_options.add_argument(
-    "--checkers",
-    type=int,
-    metavar="N",
-    help=(
-        "Maximum number of subprocesses for checking directory sources "
-        "(default: :confval:`checkers` config)"
-    ),
-)
-perf_options.add_argument(
     "--getters",
     type=int,
     metavar="N",

--- a/src/termvisage/parsers.py
+++ b/src/termvisage/parsers.py
@@ -602,15 +602,6 @@ perf_options.add_argument(
     help="Apply :option:`--max-pixels` in CLI mode",
 )
 perf_options.add_argument(
-    "--grid-renderers",
-    type=int,
-    metavar="N",
-    help=(
-        "Number of subprocesses for rendering grid cells in the TUI "
-        "(default: :confval:`grid renderers` config)"
-    ),
-)
-perf_options.add_argument(
     "--multi",
     action=BooleanOptionalAction,
     default=None,

--- a/src/termvisage/parsers.py
+++ b/src/termvisage/parsers.py
@@ -602,15 +602,6 @@ perf_options.add_argument(
     help="Apply :option:`--max-pixels` in CLI mode",
 )
 perf_options.add_argument(
-    "--getters",
-    type=int,
-    metavar="N",
-    help=(
-        "Number of threads for downloading images from URL sources "
-        "(default: :confval:`getters` config)"
-    ),
-)
-perf_options.add_argument(
     "--grid-renderers",
     type=int,
     metavar="N",

--- a/src/termvisage/tui/__init__.py
+++ b/src/termvisage/tui/__init__.py
@@ -13,6 +13,7 @@ from term_image.utils import lock_tty, write_tty
 from term_image.widget import UrwidImageScreen
 
 from .. import logging
+from ..config import config_options
 from ..utils import CSI
 from . import main, render
 from .keys import adjust_bottom_bar
@@ -36,7 +37,6 @@ def init(
         )
 
     main.DEBUG = args.debug
-    main.GRID_RENDERERS = args.grid_renderers
     main.MAX_PIXELS = args.max_pixels
     main.NO_ANIMATION = args.no_anim
     main.RECURSIVE = args.recursive
@@ -81,7 +81,7 @@ def init(
     grid_scanner = logging.Thread(target=scan_dir_grid, name="GridScanner", daemon=True)
     grid_render_manager = logging.Thread(
         target=render.manage_grid_renders,
-        args=(args.grid_renderers,),
+        args=(config_options.grid_renderers,),
         name="GridRenderManager",
         daemon=True,
     )

--- a/src/termvisage/tui/main.py
+++ b/src/termvisage/tui/main.py
@@ -717,7 +717,6 @@ update_pipe: Optional[int] = None
 
 # # Corresponsing to command-line args
 DEBUG: Optional[bool] = None
-GRID_RENDERERS: Optional[int] = None
 MAX_PIXELS: Optional[int] = None
 NO_ANIMATION: Optional[bool] = None
 RECURSIVE: Optional[bool] = None


### PR DESCRIPTION
Removes:

- `--checkers`
- `--getters`
- `--grid-renderers`

command-line options as they're rarely used. The config options are adequate.