### PR TITLE
docs: Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ We will then answer the question as soon as possible.
 
 When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the [termvisage license](/LICENSE).
 
-If by any means, any content which you didn't author is included, this should be clearly and duely noted along with any neccesary attribution and license/copyright notices.
+If by any means, any content which you didn't author is included, this should be clearly and duely noted along with any necessary attribution and license/copyright notices.
 **NOTE:** We can not guarantee that such contributions will be accepted.
 
 
@@ -129,7 +129,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/Anonym
 
 - Set up a [development environment](#setting-up-a-development-environment) (you may skip **step 1** if you wish).
 - Go through and follow the [style guides](#style-guides).
-- Before commiting changes, run the neccesary [checks](#documentation-checks), make any neccesary [correction](#documentation-corrections) and ensure they pass.
+- Before committing changes, run the necessary [checks](#documentation-checks), make any necessary [correction](#documentation-corrections) and ensure they pass.
 - Before opening a pull request, ensure the documentation [builds](#building-the-documentation) successfully.
 - Open a [pull request](https://github.com/AnonymouX47/termvisage/compare) from **a branch (of your fork) other than the default (`main`)** into the **upstream `main` branch** (except stated otherwise). Any pull request **from** the **default branch** will not be merged.
 - If the pull request is **incomplete**, convert the pull request into a **draft**.
@@ -140,7 +140,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/Anonym
 - Set up a [development environment](#setting-up-a-development-environment).
 - Ensure the bug fix or enhancement has been discussed and the approach for implementation decided. If not, [suggest the enhancement](#suggesting-enhancements) before going ahead to implementation.
 - Go through and follow the [style guides](#style-guides).
-- Before commiting changes, run all [checks](#code-checks), make any neccesary [correction](#code-corrections) and ensure they pass.
+- Before committing changes, run all [checks](#code-checks), make any necessary [correction](#code-corrections) and ensure they pass.
 - Before opening a pull request:
   - Ensure everything you've implemented up to the latest commit works as expected.
   - Note that the sub-steps above might not confer compatibility across multiple Python versions or platforms, final checks will be done automatically when you push the changes or open a pull request.
@@ -154,7 +154,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/Anonym
 
 Please put some effort into breaking your contribution up into a series of well formed commits. There is a good guide available at https://cbea.ms/git-commit/.
 
-- Always run the [checks and corrections](#pre-commit-checks-and-corrections) before commiting changes.
+- Always run the [checks and corrections](#pre-commit-checks-and-corrections) before committing changes.
 - Each commit should ideally contain only one change
 - Don't bundle multiple **unrelated** changes into a single commit
 - Write descriptive and well formatted commit messages

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -39,7 +39,7 @@ Options and Arguments
 .. [#] The size is multiplied by the scale on respective axes when an image is rendered.
    A scale value must be such that 0.0 < value <= 1.0.
 
-.. [#] Width and height are in units of columns and lines repectively.
+.. [#] Width and height are in units of columns and lines respectively.
 
    By default (i.e if none of the sizing options is specified), the equivalent of
    :option:`--original-size` is used if not larger than the :term:`available size`,

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -106,7 +106,7 @@ The command-line options are mutually exclusive and override the config option.
 
 By default (i.e without changing the config option value or specifying either
 command-line option), ``termvisage`` tries to determine the value from the
-:term:`active terminal` which works on most mordern terminal emulators (currently
+:term:`active terminal` which works on most modern terminal emulators (currently
 supported on UNIX-like platforms only).
 This is probably the best choice, except the terminal emulator or platform doesn't
 support this feature.
@@ -171,7 +171,7 @@ A log entry has the following format:
   * Only present when running on **Python 3.8+** and *logging level* is set to ``DEBUG``
     (either by :option:`--debug` or :option:`--log-level=DEBUG`).
 
-* *message*: The actual report describing the event that occured.
+* *message*: The actual report describing the event that occurred.
 
 
 .. note::
@@ -182,7 +182,7 @@ A log entry has the following format:
 
      * Only the current and immediate previous log file are kept.
 
-   * The Process ID of the each session preceeds its log entries, so this can be used to distinguish between logs from different sessions running simultaneously while using the same log file.
+   * The Process ID of the each session precedes its log entries, so this can be used to distinguish between logs from different sessions running simultaneously while using the same log file.
 
 
 .. _exit-codes:
@@ -194,5 +194,5 @@ Exit Codes
 * ``0`` (SUCCESS): Exited normally and successfully.
 * ``1`` (FAILURE): Exited due to an unhandled exception or a non-specific error.
 * ``2`` (INVALID_ARG): Exited due to an invalid command-line argument value or option combination.
-* ``3`` (INTERRUPTED): The program recieved an interrupt signal i.e ``SIGINT``.
+* ``3`` (INTERRUPTED): The program received an interrupt signal i.e ``SIGINT``.
 * ``4`` (NO_VALID_SOURCE): Exited due to lack of any valid source.

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -13,9 +13,9 @@ By default, ``termvisage`` searches the following locations, **in the specified 
 for ``$DIR/termvisage/termvisage.json`` (a file named ``termvisage.json`` within a
 directory named ``termvisage``):
 
-* All valid directories specified in the ``XDG_CONFIG_DIRS`` enviroment variable,
+* All valid directories specified in the ``XDG_CONFIG_DIRS`` environment variable,
   **in reverse order** or ``/etc/xdg`` if not set.
-* The directory specified by the ``XDG_CONFIG_HOME`` enviroment variable or ``~/.config``
+* The directory specified by the ``XDG_CONFIG_HOME`` environment variable or ``~/.config``
   if not set (where ``~`` is the current user's home directory).
 
 If multiple config files are found (i.e in different locations), they're applied on top of
@@ -173,7 +173,7 @@ These are top-level fields whose values control various settings of the viewer.
    :valid: ``"auto"``, ``"block"``, ``"iterm2"``, ``"kitty"``
    :default: ``"auto"``
 
-   If set to any value other than ``"auto"`` and is not overriden by
+   If set to any value other than ``"auto"`` and is not overridden by
    :option:`-S`, the style is used regardless of whether it's supported or not.
 
    .. note:: Overridden by :option:`-S`.

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -2,7 +2,7 @@ FAQs
 ====
 
 What about Windows support?
-   - Firstly, only the new `Windows Terminal <https://github.com/microsoft/terminal>`_ seems to have proper truecolor support and mordern terminal emulator features.
+   - Firstly, only the new `Windows Terminal <https://github.com/microsoft/terminal>`_ seems to have proper truecolor support and modern terminal emulator features.
    - The CLI mode currently works (with a few quirks), i.e using ``cmd`` or ``powershell``, if the other requirements are satisfied but can't guarantee it'll always be so.
 
      - Drawing images and animations doesn't work completely well in ``cmd`` and ``powershell``.
@@ -13,7 +13,7 @@ What about Windows support?
    - If stuck on Windows and want to use all features, you could use WSL + Windows Terminal.
 
 Why are colours not properly reproduced?
-   - Some terminals support truecolor escape sequences but have a **256-color pallete**. This limits color reproduction.
+   - Some terminals support truecolor escape sequences but have a **256-color palette**. This limits color reproduction.
 
 Why are images out of scale?
    - If *auto* :term:`cell ratio` is supported and enabled,

--- a/docs/source/gallery.rst
+++ b/docs/source/gallery.rst
@@ -91,7 +91,7 @@ Sizing (CLI only)
    :preload: metadata
 
 * Size images based on terminal size or original image size.
-* Specifiy image width or height (in columns or lines respectively).
+* Specify image width or height (in columns or lines respectively).
 
 Alignment/Padding (CLI only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -59,4 +59,4 @@ For render style-specific support, see :ref:`render-styles`.
 
 .. note::
    Some terminal emulators support truecolor escape sequences but have a
-   256-color pallete. This will limit color reproduction.
+   256-color palette. This will limit color reproduction.

--- a/src/termvisage/__main__.py
+++ b/src/termvisage/__main__.py
@@ -95,7 +95,7 @@ def main() -> int:
         return exit_code
     finally:
         write_tty(b"\033[23;2t")  # Restore window title
-        # Explicit cleanup is neccessary since the top-level `Image` widgets
+        # Explicit cleanup is necessary since the top-level `Image` widgets
         # will still hold references to the `BaseImage` instances
         if cli.url_images:
             for _, value in cli.url_images:

--- a/src/termvisage/cli.py
+++ b/src/termvisage/cli.py
@@ -114,7 +114,7 @@ def check_dir(
     Args:
         - dir: Path to directory to be scanned.
         - prev_dir: Path (absolute or relative to *dir*) to set as working directory
-          after scannning *dir* (default:  parent directory of *dir*).
+          after scanning *dir* (default:  parent directory of *dir*).
         - _links: Tracks all symlinks from a *source* up **till** a subdirectory.
 
     Returns:

--- a/src/termvisage/logging.py
+++ b/src/termvisage/logging.py
@@ -145,7 +145,7 @@ def log_exception(
     direct: bool = False,
     fatal: bool = False,
 ) -> None:
-    """Report an error with the exception reponsible
+    """Report an error with the exception responsible
 
     NOTE: Should be called from within an exception handler
     i.e from (also possibly in a nested context) within an except or finally clause.

--- a/src/termvisage/logging_multi.py
+++ b/src/termvisage/logging_multi.py
@@ -43,12 +43,12 @@ def process_multi_logs() -> None:
 class Process(Process):
     """A process with integration into the logging system
 
-    Sets up the logging system to redirect all logs (and optionally notifcations)
+    Sets up the logging system to redirect all logs (and optionally notifications)
     in the subprocess, to the main process to be emitted.
 
     NOTE:
         - Only TUI notifications need to be redirected.
-        - The redirected logs and notifcations are automatically handled by
+        - The redirected logs and notifications are automatically handled by
           `process_multi_logs()`, running in the MultiLogger thread of the main process.
     """
 

--- a/src/termvisage/parsers.py
+++ b/src/termvisage/parsers.py
@@ -514,7 +514,7 @@ sizing_options.add_argument(
     type=float,
     metavar="N",
     default=1.0,
-    help="Image horizontal :term:`scale` (overriden by :option:`-s`) (default: 1.0)",
+    help="Image horizontal :term:`scale` (overridden by :option:`-s`) (default: 1.0)",
 )
 sizing_options.add_argument(
     "-y",
@@ -522,7 +522,7 @@ sizing_options.add_argument(
     type=float,
     metavar="N",
     default=1.0,
-    help="Image vertical :term:`scale` (overriden by :option:`-s`) (default: 1.0)",
+    help="Image vertical :term:`scale` (overridden by :option:`-s`) (default: 1.0)",
 )
 
 # # Alignment
@@ -577,7 +577,7 @@ tui_options.add_argument(
     "-a",
     "--all",
     action="store_true",
-    help="Inlcude hidden file and directories",
+    help="Include hidden file and directories",
 )
 tui_options.add_argument(
     "-r",

--- a/src/termvisage/tui/__init__.py
+++ b/src/termvisage/tui/__init__.py
@@ -137,7 +137,7 @@ def init(
 
 class Loop(urwid.MainLoop):
     def start(self):
-        adjust_bottom_bar()  # Properly set expand key visbility at initialization
+        adjust_bottom_bar()  # Properly set expand key visibility at initialization
         return super().start()
 
     def process_input(self, keys):

--- a/src/termvisage/tui/keys.py
+++ b/src/termvisage/tui/keys.py
@@ -259,7 +259,7 @@ def register_key(*args: Tuple[str, str]) -> FunctionType:
 
     def register(func: FunctionType) -> None:
         """Registers *func* to the key corresponding to each ``(context, action)`` pair
-        recieved by the call to ``register_key()`` that defines it.
+        received by the call to ``register_key()`` that defines it.
         """
         for context, action in args:
             # All actions are enabled by default
@@ -282,7 +282,7 @@ def set_confirmation(
 
     Args:
       - msg: The message to be displayed in the dialog.
-      - bottom_widget: The widget on which the confirmation dialog will be overlayed.
+      - bottom_widget: The widget on which the confirmation dialog will be overlaid.
       - confirm: A function to be called for the "Confirm" action of the
         confirmation context.
       - cancel: A function to be called for the "Cancel" action of the

--- a/src/termvisage/tui/main.py
+++ b/src/termvisage/tui/main.py
@@ -715,7 +715,7 @@ displayer: Optional[Generator[None, int, bool]] = None
 loop: Optional[tui.Loop] = None
 update_pipe: Optional[int] = None
 
-# # Corresponsing to command-line args
+# # Corresponding to command-line args
 DEBUG: Optional[bool] = None
 MAX_PIXELS: Optional[int] = None
 NO_ANIMATION: Optional[bool] = None

--- a/src/termvisage/tui/render.py
+++ b/src/termvisage/tui/render.py
@@ -143,7 +143,7 @@ def manage_image_renders():
 
     def not_skip():
         # If this image is the one currently displayed but the queue is non empty,
-        # it means some "forth and back" has occured.
+        # it means some "forth and back" has occurred.
         # Skipping this render avoids the possibility of wasting time with this render
         # in the case where the image size has changed.
         return image_w is image_box.original_widget and image_render_queue.empty()
@@ -172,7 +172,7 @@ def manage_image_renders():
 
     try:
         while True:
-            # A redraw is neccesary even when the render is skipped, in case the skipped
+            # A redraw is necessary even when the render is skipped, in case the skipped
             # render is of the currently displayed image.
             # So that a new render can be sent in (after `._ti_rendering` is unset).
             # Otherwise, the image will remain unrendered until a redraw.
@@ -224,7 +224,7 @@ def manage_grid_renders(n_renderers: int):
 
     Intended to be executed in a separate thread of the main process.
 
-    If multiprocessing is enabled and *n_renderers* > 0, it spwans *n_renderers*
+    If multiprocessing is enabled and *n_renderers* > 0, it spawns *n_renderers*
     subprocesses to render the cells and handles their proper termination.
     Otherwise, it starts a single new thread to render the cells.
     """
@@ -495,7 +495,7 @@ grid_style_specs = {"kitty": "+L", "iterm2": "+L"}
 image_style_specs = {"kitty": "+W", "iterm2": "+W"}
 
 # Set from `.tui.init()`
-# # Corresponsing to command-line args
+# # Corresponding to command-line args
 ANIM_CACHED: Union[None, bool, int] = None
 FRAME_DURATION: Optional[float] = None
 REPEAT: Optional[int] = None

--- a/src/termvisage/tui/widgets.py
+++ b/src/termvisage/tui/widgets.py
@@ -404,7 +404,7 @@ class ImageCanvas(urwid.Canvas):
     def content(self, trim_left=0, trim_top=0, cols=None, rows=None, attr_map=None):
         # In all our use cases, the canvas is never trimmed horizontally
         cols = self.cols()
-        rows = rows or self.rows()  # Visble rows of the widget
+        rows = rows or self.rows()  # Visible rows of the widget
         trim_bottom = self.rows() - trim_top - rows
 
         diff_x, diff_y = map(sub, self.size, self._ti_image_size)


### PR DESCRIPTION
Found via `codespell`