### PR TITLE
Improvements to Image Grid Cell Size Adjustemt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - config: Changed the default value of the `max pixels` config option to `0` (disabled).
   - tui: It no longer applies in the `full-grid-image` context.
   - tui: In the `image-grid` context, images with more pixels than *max pixels* (**if non-zero**) are now distinguished by a yellow title and border.
+- tui: Improved image grid cell size adjustment ([#15]).
 
 ### Removed
 - args: `--max-pixels-cli` command-line option ([#13]).
 
 [#13]: https://github.com/AnonymouX47/termvisage/pull/13
+[#15]: https://github.com/AnonymouX47/termvisage/pull/15
 [c64f195]: https://github.com/AnonymouX47/termvisage/commit/c64f195a79557fdf5a9323db907a5716a12d6440
 [9ea0572]: https://github.com/AnonymouX47/termvisage/commit/9ea0572e6db35984a4ae0af1691edfd179e5d393
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -67,7 +67,7 @@ These are top-level fields whose values control various settings of the viewer.
 .. confval:: cell width
    :synopsis: The initial width of (no of columns for) grid cells, in the TUI.
    :type: integer
-   :valid: ``30`` <= *x* <= ``50`` and *x* is even
+   :valid: ``10`` <= *x* <= ``50`` and *x* is even
    :default: ``30``
 
 .. confval:: checkers

--- a/src/termvisage/config.py
+++ b/src/termvisage/config.py
@@ -559,8 +559,8 @@ config_options = {
     ),
     "cell width": Option(
         30,
-        lambda x: isinstance(x, int) and 30 <= x <= 50 and not x % 2,
-        "must be an even integer between 30 and 50 (both inclusive)",
+        lambda x: isinstance(x, int) and 10 <= x <= 50 and not x % 2,
+        "must be an even integer between 10 and 50 (both inclusive)",
     ),
     "checkers": Option(
         None,

--- a/src/termvisage/tui/keys.py
+++ b/src/termvisage/tui/keys.py
@@ -489,7 +489,7 @@ def maximize():
 # image-grid
 @register_key(("image-grid", "Size-"))
 def cell_width_dec():
-    if image_grid.cell_width > 30:
+    if image_grid.cell_width > 10:
         image_grid.cell_width -= 2
         resync_grid_rendering()
         getattr(main.ImageClass, "clear", lambda: True)()

--- a/src/termvisage/tui/keys.py
+++ b/src/termvisage/tui/keys.py
@@ -489,10 +489,16 @@ def maximize():
 # image-grid
 @register_key(("image-grid", "Size-"))
 def cell_width_dec():
+    if image_grid.cell_width == 50:
+        main.enable_actions("image-grid", "Size+")
+
     if image_grid.cell_width > 10:
         image_grid.cell_width -= 2
         resync_grid_rendering()
         getattr(main.ImageClass, "clear", lambda: True)()
+
+        if image_grid.cell_width == 10:
+            main.disable_actions("image-grid", "Size-")
 
     if main.THUMBNAIL:
         Image._ti_update_grid_thumbnailing_threshold(_prev_cell_size)
@@ -500,10 +506,16 @@ def cell_width_dec():
 
 @register_key(("image-grid", "Size+"))
 def cell_width_inc():
+    if image_grid.cell_width == 10:
+        main.enable_actions("image-grid", "Size-")
+
     if image_grid.cell_width < 50:
         image_grid.cell_width += 2
         resync_grid_rendering()
         getattr(main.ImageClass, "clear", lambda: True)()
+
+        if image_grid.cell_width == 50:
+            main.disable_actions("image-grid", "Size+")
 
     if main.THUMBNAIL:
         Image._ti_update_grid_thumbnailing_threshold(_prev_cell_size)


### PR DESCRIPTION
- Changes the lower bound for the grid cell width from `30` to `10` columns.
- The `Size-` and `Size+` actions in the `image-grid` context are now dynamically disabled/enabled.

Addresses https://github.com/AnonymouX47/termvisage/issues/12#issuecomment-2084327680 .